### PR TITLE
Disabled test during makepkg

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-pointcloud-to-laserscan
 	pkgdesc = ROS - Converts a 3D Point Cloud into a 2D laser scan.
 	pkgver = 1.4.1
-	pkgrel = 3
+	pkgrel = 4
 	url = https://wiki.ros.org/perception_pcl
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@ url='https://wiki.ros.org/perception_pcl'
 pkgname='ros-melodic-pointcloud-to-laserscan'
 pkgver='1.4.1'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=3
+pkgrel=4
 license=('BSD')
 
 ros_makedepends=(ros-melodic-tf2-sensor-msgs
@@ -49,6 +49,7 @@ build() {
   cmake ${srcdir}/${_dir} \
         -DCMAKE_BUILD_TYPE=Release \
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
+        -DCATKIN_ENABLE_TESTING=0 \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic \
         -DPYTHON_EXECUTABLE=/usr/bin/python3 \
         -DSETUPTOOLS_DEB_LAYOUT=OFF


### PR DESCRIPTION
This way we can avoid adding the test dependencies to the PKGBUILD

This makes #1 obsolete.